### PR TITLE
Ignore vendor directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 
 # Build output
 /opa-docker-authz
+/vendor


### PR DESCRIPTION
The deps are downloaded during the build. We don't want to include them
in the repo.

/cc @msanvido 