### PR TITLE
Update plugin to embed OPA as a library

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM alpine
+
+MAINTAINER Torin Sandall <torinsandall@gmail.com>
+
+ADD opa-docker-authz /opa-docker-authz
+
+ENTRYPOINT ["/opa-docker-authz"]

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,12 @@
 .PHONY: all build
 
+VERSION := 0.2
+
 all: build
 
 build:
-	@docker run -it --rm -v $(PWD):/go/src/github.com/open-policy-agent/opa-docker-authz golang:1.6 \
+	@docker run -it --rm -e VERSION=$(VERSION) -v $(PWD):/go/src/github.com/open-policy-agent/opa-docker-authz golang:1.8 \
 		/go/src/github.com/open-policy-agent/opa-docker-authz/build.sh
+
+image: build
+	@docker build -t openpolicyagent/opa-docker-authz:$(VERSION) -f Dockerfile .

--- a/README.md
+++ b/README.md
@@ -2,25 +2,26 @@
 
 This project is used to show how OPA can help policy-enable an existing service.
 
-In this example, we policy-enable the authorization functionality available in Docker 1.10 and later.
+In this example, we policy-enable the authorization functionality available in
+Docker 1.10 and later.
 
 ## Usage
 
-See the [detailed example](http://www.openpolicyagent.org/tutorials/docker-authorization/) to setup a running example of this plugin.
+See the [detailed example](http://www.openpolicyagent.org/docs/docker-authorization.html) to setup a running example of this plugin.
 
 ### Build
 
-To build the plugin, run (requires Docker):
-
-    $ make
+To build the plugin run `make`. The build requires Docker.
 
 ### Install
 
-The plugin can be started with no options. It may require sudo depending on your machine's Docker configuration permissions:
+The plugin can be started with no options. It may require sudo depending on your
+machine's Docker configuration permissions:
 
     $ opa-docker-authz
 
-- By default, the plugin will listen for requests (from Docker) on :8080 and contacts OPA on :8181.
+- By default, the plugin will listen for requests (from Docker) on :8080 and
+  read an OPA policy out of `policy.rego`. See `-h` for options.
 
 The following command line argument enables the authorization plugin within Docker:
 
@@ -36,7 +37,3 @@ On Ubuntu 16.04 this is done by overriding systemd configuration (requires root)
     EOF
     $ sudo systemctl daemon-reload
     $ sudo service docker restart
-
-### Testing
-
-The plugin will upsert a policy definition (by default, "example.rego") into OPA on startup and then establish a file watch to be notified when the definition changes. Each time the definition changes, the plugin will upsert into OPA.

--- a/build.sh
+++ b/build.sh
@@ -2,6 +2,8 @@
 
 set -ex
 
+echo "building version: $VERSION"
+
 cd /go/src/github.com/open-policy-agent/opa-docker-authz
 
 echo "install glide"
@@ -11,4 +13,4 @@ echo "install all the dependencies"
 glide install
 
 echo "build opa-docker-authz"
-go build -o opa-docker-authz
+CGO_ENABLED=0 go build -ldflags "-X github.com/open-policy-agent/opa-docker-authz.Version=$VERSION" -o opa-docker-authz

--- a/glide.lock
+++ b/glide.lock
@@ -1,12 +1,14 @@
-hash: 19c9a06c02290bc91bdfd7361eb8121aa59cff9ce991565ce35c32688d476bf9
-updated: 2017-12-14T10:50:28.969428519-08:00
+hash: 19293eb44aec5bcb77cdc582c3444febeb25d7270c904516d01cafc56719260d
+updated: 2018-02-16T08:20:55.852826-08:00
 imports:
 - name: github.com/coreos/go-systemd
-  version: c966a8af8422394b2e370d90e2101adba21c14be
+  version: 25fe332a900022d06a189ce01108392854c59df1
   subpackages:
   - activation
+- name: github.com/dchest/siphash
+  version: 4ebf1de738443ea7f45f02dc394c4df1942a126d
 - name: github.com/docker/go-connections
-  version: 3ede32e2033de7505e6500d6c868c2b9ed9f169d
+  version: 7beb39f0b969b075d1325fecb092faf27fd357b6
   subpackages:
   - sockets
 - name: github.com/docker/go-plugins-helpers
@@ -16,15 +18,32 @@ imports:
   - sdk
 - name: github.com/fsnotify/fsnotify
   version: 4da3e2cfbabc9f751898f250b49f2439785783a1
+- name: github.com/ghodss/yaml
+  version: 0ca9ea5df5451ffdf184b4428c902747c2c11cd7
 - name: github.com/Microsoft/go-winio
-  version: 78439966b38d69bf38227fbf57ac8a6fee70f69a
+  version: 7da180ee92d8bd8bb8c37fc560e673e6557c392f
+- name: github.com/open-policy-agent/opa
+  version: 43fcc6ae25d1aacab0649caf022d7e6209d7f8a7
+  subpackages:
+  - ast
+  - metrics
+  - rego
+  - storage
+  - storage/inmem
+  - topdown
+  - topdown/builtins
+  - types
+  - util
+- name: github.com/pkg/errors
+  version: 30136e27e2ac8d167177e8a583aa4c3fea5be833
 - name: golang.org/x/net
-  version: d866cfc389cec985d6fda2859936a575a55a3ab6
+  version: 1c05540f6879653db88113bc4a2b70aec4bd491f
   subpackages:
   - proxy
 - name: golang.org/x/sys
-  version: 1d2aa6dbdea45adaaebb9905d0666e4537563829
+  version: 37707fdb30a5b38865cfb95e5aab41707daec7fd
   subpackages:
-  - unix
   - windows
+- name: gopkg.in/yaml.v2
+  version: d670f9405373e636a5a2765eea47fac0c9bc91a4
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -6,3 +6,5 @@ import:
   - authorization
 - package: github.com/fsnotify/fsnotify
   version: 4da3e2cfbabc9f751898f250b49f2439785783a1
+- package: github.com/open-policy-agent/opa
+  version: v0.6.0


### PR DESCRIPTION
These changes reduce the system administration overhead of deploying OPA
as an authorization plugin. With these changes, opa-docker-authz can
also be run as a container.