### PR TITLE
Implement Docker's managed plugin format

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,18 @@
-FROM alpine
+FROM alpine AS default-policy
 
-MAINTAINER Torin Sandall <torinsandall@gmail.com>
+RUN echo -e 'package docker.authz\n\
+allow = true'\
+>> /default.rego
 
-ADD opa-docker-authz /opa-docker-authz
+FROM scratch AS image
+
+LABEL maintainer="Torin Sandall <torinsandall@gmail.com>"
+
+COPY opa-docker-authz /opa-docker-authz
 
 ENTRYPOINT ["/opa-docker-authz"]
+
+FROM image
+
+COPY --from=default-policy /default.rego /default.rego
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,7 @@
-FROM alpine AS default-policy
-
-RUN echo -e 'package docker.authz\n\
-allow = true'\
->> /default.rego
-
-FROM scratch AS image
+FROM scratch
 
 LABEL maintainer="Torin Sandall <torinsandall@gmail.com>"
 
 COPY opa-docker-authz /opa-docker-authz
 
 ENTRYPOINT ["/opa-docker-authz"]
-
-FROM image
-
-COPY --from=default-policy /default.rego /default.rego
-

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,46 @@
 .PHONY: all build
 
 VERSION := 0.2.2
+OPA_VERSION := 0.8.0
+GO_VERSION := 1.10
+REPO := openpolicyagent/opa-docker-authz
 
 all: build
 
 build:
-	@docker run -it --rm -e VERSION=$(VERSION) -v $(PWD):/go/src/github.com/open-policy-agent/opa-docker-authz golang:1.8 \
-		/go/src/github.com/open-policy-agent/opa-docker-authz/build.sh
+	@docker container run --rm \
+		-e VERSION=$(VERSION) \
+		-e OPA_VERSION=$(OPA_VERSION) \
+		-v $(PWD):/go/src/github.com/open-policy-agent/opa-docker-authz \
+		-w /go/src/github.com/open-policy-agent/opa-docker-authz \
+		golang:$(GO_VERSION) \
+		./build.sh
+	@sudo rm -rf ./vendor
 
 image: build
-	@docker build -t openpolicyagent/opa-docker-authz:$(VERSION) -f Dockerfile .
+	@docker image build \
+		--target image \
+		--tag $(REPO):$(VERSION) \
+		.
+ 
+plugin: build
+	@mkdir ./rootfs
+	@echo "\nCreating root filesystem for plugin ..."
+	@docker image build -t rootfsimage .
+	@id=$$(docker container create rootfsimage true) && \
+	sudo docker container export $$id | sudo tar -x -C ./rootfs && \
+	docker container rm -f $$id
+	@docker image rm -f rootfsimage
+	@echo "\nCreating plugin $(REPO):$(VERSION) ..."
+	@sudo docker plugin create $(REPO):$(VERSION) .
+	@sudo rm -rf ./rootfs
+
+plugin-push: plugin
+	@echo "\nPushing plugin $(REPO):$(VERSION) ..."
+	@docker plugin push $(REPO):$(VERSION)
+
+clean:
+	@echo "\nRemoving opa-docker-authz binary ..."
+	@rm -rfv ./opa-docker-authz
+	@echo "\nRemoving local copy of plugin $(REPO):$(VERSION) ..."
+	@docker plugin rm -f $(REPO):$(VERSION)

--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 This project is used to show how OPA can help policy-enable an existing service.
 
-In this example, we policy-enable the authorization functionality available in
-Docker 1.10 and later.
+In this example, we policy-enable the authorization functionality available in the Docker Engine, which is implemented using a plugin architecture. Plugins were introduced in the Docker Engine in 1.10, as a v1 implementation, and further extended in 1.13, as a v2 implementation. Plugins that adhere to the former are often termed [legacy plugins](https://docs.docker.com/engine/extend/legacy_plugins/), whilst the latter are termed [managed plugins](https://docs.docker.com/engine/extend/).
+
+`opa-docker-authz` is an [authorization plugin](https://docs.docker.com/engine/extend/plugins_authorization/) for the Docker Engine, and can be run as a legacy plugin, or as a managed plugin. The managed plugin is the recommended configuration.
 
 ## Usage
 
@@ -11,29 +12,90 @@ See the [detailed example](http://www.openpolicyagent.org/docs/docker-authorizat
 
 ### Build
 
-To build the plugin run `make`. The build requires Docker.
+A makefile is provided for creating different artifacts, each of which requires Docker:
+
+- `make build` - builds the `opa-docker-authz` binary
+- `make image` - builds a Docker image for use as a legacy plugin
+- `make plugin` - builds a managed plugin
 
 ### Install
 
-The plugin can be started with no options. It may require sudo depending on your
-machine's Docker configuration permissions:
+To make use of the `opa-docker-authz` plugin, [TLS must be enabled](https://docs.docker.com/engine/security/https/), in order for the Docker daemon to authenticate the client user. The client's X.509 certificate subject common name, should be [configured](https://docs.docker.com/engine/extend/plugins_authorization/#default-user-authorization-mechanism) with the user who is the subject of the authorization request.
 
-    $ opa-docker-authz
+**Managed Plugin**
 
-- By default, the plugin will listen for requests (from Docker) on :8080 and
-  read an OPA policy out of `policy.rego`. See `-h` for options.
+The managed plugin is configured with some default policy, which simply allows all Docker client API calls, irrespective of user. The following steps detail how to install the managed plugin.
 
-The following command line argument enables the authorization plugin within Docker:
+Download the `opa-docker-authz` plugin from the Docker Hub (depending on how your Docker environment is configured, you may need to execute the following commands using the `sudo` utility):
 
-    --authorization-plugin=opa-docker-authz
+```
+$ docker plugin install openpolicyagent/opa-docker-authz:0.2.2 --alias opa-docker-authz
+Plugin "openpolicyagent/opa-docker-authz:0.2.2" is requesting the following privileges:
+ - mount: [/etc/docker]
+Do you grant the above permissions? [y/N] y
+0.2.2: Pulling from openpolicyagent/opa-docker-authz
+63ee1bb73b80: Download complete 
+Digest: sha256:f76ed8a2fa08d1c144ddf14b9c872590bc5021482602b182b7035255fc8975ab
+Status: Downloaded newer image for openpolicyagent/opa-docker-authz:0.2.2
+Installed plugin openpolicyagent/opa-docker-authz:0.2.2
+```
 
-On Ubuntu 16.04 this is done by overriding systemd configuration (requires root):
+Check the plugin is installed and enabled:
 
-    $ sudo mkdir -p /etc/systemd/system/docker.service.d
-    $ sudo tee -a /etc/systemd/system/docker.service.d/override.conf > /dev/null <<EOF
-    [Service]
-    ExecStart=
-    ExecStart=/usr/bin/docker daemon -H fd:// --authorization-plugin=opa-docker-authz
-    EOF
-    $ sudo systemctl daemon-reload
-    $ sudo service docker restart
+```
+$ docker plugin ls --format 'table {{.ID}}\t{{.Name}}\t{{.Enabled}}'
+ID                  NAME                      ENABLED
+ef6e3b335fa9        opa-docker-authz:latest   true
+```
+
+With the plugin installed and enabled, the Docker daemon needs to be configured to make use of the plugin. There are a couple of ways of doing this, but perhaps the easiest is to add a configuration option to the daemon's configuration file (usually `/etc/docker/daemon.json`):
+
+```json
+{
+    "authorization-plugins": ["opa-docker-authz"]
+}
+```
+
+To update the Docker daemon's configuration, send a `HUP` signal to its process:
+
+```
+$ sudo kill -HUP $(pidof dockerd)
+```
+
+The Docker daemon will now send authorization requests for all Docker client API calls, to the `opa-docker-authz` plugin, for evaluation.
+
+Of course, the default policy is of little use, as it simply allows all requests to be authorized. To enable custom policy use for `opa-docker-authz`, the plugin is configured with a bind mount; `/etc/docker` is mounted at `/opa` inside the plugin's container. If you define your policy in a file located at the path `/etc/docker/policies/authz.rego`, for example, it will be available to the plugin at `/opa/policies/authz.rego`.
+
+To have the `opa-docker-authz` plugin make use of the user-defined policy, specify the additional arguments during plugin installation:
+
+```
+$ docker plugin install openpolicyagent/opa-docker-authz:0.2.2 \
+    opa-args="-policy-file /opa/policies/authz.rego" \
+    --alias opa-docker-authz
+```
+
+If an alternate host location is preferred for the bind mount, then it's possible to set the source during plugin installation. For example, if policy files are located in `$HOME/opa/policies`, then a policy file called `authz.rego` can be made available to the plugin, with the following:
+
+```
+$ docker plugin install openpolicyagent/opa-docker-authz:0.2.2 \
+    policy.source=$HOME/opa/policies \
+    opa-args="-policy-file /opa/authz.rego" \
+    --alias opa-docker-authz
+```
+
+**Legacy Plugin**
+
+If you prefer to use the legacy plugin, it needs to be started as a container, before applying the same configuration to the Docker daemon, as detailed above:
+
+```
+$ docker container run -d --restart=always --name opa-docker-authz \
+    -v /run/docker/plugins:/run/docker/plugins \
+    -v $HOME/opa/policies:/opa \
+    openpolicyagent/opa-docker-authz:0.2.2 -policy-file /opa/authz.rego
+```
+
+### Uninstall
+
+Uninstalling the `opa-docker-authz` plugin is the reverse of installing. First, remove the configuration applied to the Docker daemon, not forgetting to send a `HUP` signal to the daemon's process.
+
+If you're using the legacy plugin, use the `docker container rm -f opa-docker-authz` command to remove the plugin. Otherwise, use the `docker plugin rm -f opa-docker-authz` to remove the managed plugin.

--- a/build.sh
+++ b/build.sh
@@ -1,18 +1,21 @@
 #!/usr/bin/env bash
 
-set -ex
+set -e
 
-echo "building version: $VERSION"
+echo "Building opa-docker-authz version: $VERSION"
 
-cd /go/src/github.com/open-policy-agent/opa-docker-authz
+echo -e "\nInstalling glide ..."
+curl -s https://glide.sh/get | sh
 
-echo "install glide"
-curl https://glide.sh/get | sh
-
-echo "install all the dependencies"
+echo -e "\nInstalling all the dependencies ..."
 glide install
 
-OPA_VERSION=$(grep 'package: github.com/open-policy-agent/opa$' glide.yaml -A 1 | tail -n 1 | awk '{print $2}')
+echo -e "\nSetting OPA version to $OPA_VERSION ..."
+sed -i "s/\(  version: v\)[0-9]\.[0-9]\.[0-9]/\1$OPA_VERSION/g" glide.yaml
 
-echo "build opa-docker-authz"
-CGO_ENABLED=0 go build -ldflags "-X github.com/open-policy-agent/opa-docker-authz/version.Version=$VERSION -X github.com/open-policy-agent/opa-docker-authz/version.OPAVersion=$OPA_VERSION" -o opa-docker-authz
+echo -e "\nBuilding opa-docker-authz ..."
+CGO_ENABLED=0 go build -ldflags \
+    "-X github.com/open-policy-agent/opa-docker-authz/version.Version=$VERSION -X github.com/open-policy-agent/opa-docker-authz/version.OPAVersion=$OPA_VERSION" \
+    -o opa-docker-authz
+
+echo -e "\n... done!"

--- a/build.sh
+++ b/build.sh
@@ -17,5 +17,6 @@ echo -e "\nBuilding opa-docker-authz ..."
 CGO_ENABLED=0 go build -ldflags \
     "-X github.com/open-policy-agent/opa-docker-authz/version.Version=$VERSION -X github.com/open-policy-agent/opa-docker-authz/version.OPAVersion=$OPA_VERSION" \
     -o opa-docker-authz
+rm -rf ./vendor
 
 echo -e "\n... done!"

--- a/config.json
+++ b/config.json
@@ -1,0 +1,27 @@
+{
+    "description": "A policy-enabled authorization plugin for Docker",
+    "documentation": "https://www.openpolicyagent.org/docs/docker-authorization.html",
+    "entrypoint": [
+        "/opa-docker-authz"
+    ],
+    "args": {
+        "name": "opa-args",
+        "description": "Arguments for opa-docker-authz",
+        "settable": ["value"],
+        "value": ["-policy-file", "/default.rego"]
+    },
+    "interface": {
+        "socket": "opa-docker-authz.sock",
+        "types": ["docker.authz/1.0"]
+    },
+    "mounts": [
+       {
+            "name": "policy",
+            "source": "/etc/docker",
+            "destination": "/opa",
+            "type": "none",
+            "options": ["bind", "ro"],
+            "settable": ["source"]
+       } 
+    ]
+}

--- a/config.json
+++ b/config.json
@@ -8,7 +8,7 @@
         "name": "opa-args",
         "description": "Arguments for opa-docker-authz",
         "settable": ["value"],
-        "value": ["-policy-file", "/default.rego"]
+        "value": ["-policy-file", "policy.rego"]
     },
     "interface": {
         "socket": "opa-docker-authz.sock",
@@ -23,5 +23,6 @@
             "options": ["bind", "ro"],
             "settable": ["source"]
        } 
-    ]
+    ],
+    "workdir": "/opa"
 }

--- a/main.go
+++ b/main.go
@@ -55,6 +55,11 @@ func (p DockerAuthZPlugin) AuthZRes(r authorization.Request) authorization.Respo
 
 func (p DockerAuthZPlugin) evaluate(ctx context.Context, r authorization.Request) (bool, error) {
 
+	if _, err := os.Stat(p.policyFile); os.IsNotExist(err) {
+		log.Printf("OPA policy file %s does not exist, failing open and allowing request", p.policyFile)
+		return true, err
+	}
+
 	bs, err := ioutil.ReadFile(p.policyFile)
 	if err != nil {
 		return false, err

--- a/plugin.sh
+++ b/plugin.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+set -e
+
+static_url="https://download.docker.com/linux/static"
+
+echo -e "\nPreparing to build plugin ..."
+
+# Determine the channel (stable, edge nightly) required for the Docker client
+if [[ "$DOCKER_VERSION" =~ ^0\.0\.0-[0-9]{14}-[0-9a-f]{7}$ ]]; then
+    channel=nightly
+elif [[ "$DOCKER_VERSION" =~ [0-9]{2}\.[0-9]{2}.[0-9]+-ce$ ]]; then
+    month=$(echo "$DOCKER_VERSION" | cut -d '.' -f 2 | sed 's/^0*//')
+    if [[ $(( month % 3 )) == 0 ]]; then
+        channel=stable
+    else
+        channel=edge
+    fi
+else
+    echo "Cannot determine the version of the Docker daemon. Aborting ..."
+    exit 1
+fi
+
+# Download a version of the Docker client for the container, that matches the
+# version of the Docker daemon
+curl -s -L "${static_url}/${channel}/x86_64/docker-${DOCKER_VERSION}.tgz" | \
+tar xzf - -C /usr/local/bin --strip-components=1 docker/docker
+
+# Check that a plugin of the same name doesn't already exist
+for plugin in $(docker plugin ls --format '{{.Name}}'); do
+    if [ "$plugin" == "${REPO}-v2:${VERSION}" ]; then
+        echo "The plugin "$plugin" already exists. Aborting ..."
+        exit 1
+    fi
+done
+
+# Remove any residual filesystem content from a previous build
+[ -d ./rootfs ] && rm -rf ./rootfs
+mkdir ./rootfs
+
+echo -e "\nCreating root filesystem for plugin ..."
+
+# Export filesystem content from a container derived from an image build from
+# plugin Dockerfile
+docker image build -t rootfsimage .
+id=$(docker container create rootfsimage true)
+docker container export "$id" | tar -x -C ./rootfs
+
+echo -e "\nCreating plugin "${REPO}-v2:${VERSION}" ..."
+
+docker plugin create "${REPO}-v2:${VERSION}" .
+
+echo -e "\nCleaning up ..."
+docker container rm -f "$id" > /dev/null
+docker image rm -f rootfsimage > /dev/null
+rm -rf ./rootfs
+
+echo -e "\n... done!"


### PR DESCRIPTION
Configures `opa-docker-authz` as a Docker managed plugin (v2), and fixes #4. 

The changes allow the legacy plugin image to be created, in addition to the new v2 plugin, for backwards compatibility. The only issue is that both can't have the same name (i.e. openpolicyagent/opa-docker-authz). Maybe the managed plugin can be hosted on the Docker Store instead of the Docker Hub, where there are currently [zero authorization plugins](https://store.docker.com/search?type=plugin&category=authorization)?