### PR TITLE
bump opa to v0.18.0, opa-docker-authz 0.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: all build
 
-VERSION := 0.5
+VERSION := 0.6
 OPA_VERSION := $(shell ./get-opa-version-from-glide.sh)
 GO_VERSION := 1.10
 REPO := openpolicyagent/opa-docker-authz

--- a/glide.yaml
+++ b/glide.yaml
@@ -7,4 +7,4 @@ import:
 - package: github.com/fsnotify/fsnotify
   version: 4da3e2cfbabc9f751898f250b49f2439785783a1
 - package: github.com/open-policy-agent/opa
-  version: v0.13.5
+  version: v0.18.0


### PR DESCRIPTION
Pick up the latest version of opa and bump to version 0.6