### PR TITLE
Add PathPlain, PathArr and Query to input map for easier policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,28 +86,43 @@ Logs are generated in a json format similar to [decision logs](https://www.openp
 
 ```
 {
-  "config_hash": "bffa4f89a49962806b21d650aea8cf086a37f85f16402e1ff7b7f4f97b8d0d30",
-  "decision_id": "65752c84-87df-4f5d-b5a3-886049811d53",
+  "config_hash": "a2e84e38eafd14a816194357860b253becbc739e601cf4307078413a0a578a89",
+  "decision_id": "8d4c6d08-b56e-4625-b66c-3e6c00d7a6e7",
   "input": {
     "AuthMethod": "",
     "Body": null,
     "Headers": {
-      "Accept-Encoding": "gzip",
-      "Connection": "close",
-      "User-Agent": "go-dockerclient"
+      "Content-Length": "0",
+      "Content-Type": "text/plain",
+      "User-Agent": "Docker-Client/19.03.11 (linux)"
     },
-    "Method": "GET",
-    "Path": "/containers/json?",
+    "Method": "POST",
+    "Path": "/v1.40/images/create?fromImage=registry.company.com%3A8885%2Fbash\\u0026tag=latest",
+    "PathArr": [
+      "",
+      "v1.40",
+      "images",
+      "create"
+    ],
+    "PathPlain": "/v1.40/images/create",
+    "Query": {
+      "fromImage": [
+        "registry.company.com:8885/bash"
+      ],
+      "tag": [
+        "latest"
+      ]
+    },
     "User": ""
   },
   "labels": {
     "app": "opa-docker-authz",
-    "id": "ee6c52bb-496e-41c2-bbfa-d056f7783d7e",
+    "id": "396f1138-ea63-4be0-9ce0-3184cb20b1dd",
     "opa_version": "v0.18.0",
-    "plugin_version": "0.7"
+    "plugin_version": "0.8"
   },
   "result": true,
-  "timestamp": "2020-05-13T21:37:29.91447041Z"
+  "timestamp": "2020-06-16T16:44:54.328705305Z"
 }
 ```
 

--- a/main.go
+++ b/main.go
@@ -15,7 +15,9 @@ import (
 	"io"
 	"io/ioutil"
 	"log"
+	"net/url"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/docker/go-plugins-helpers/authorization"
@@ -142,9 +144,17 @@ func makeInput(r authorization.Request) (interface{}, error) {
 		}
 	}
 
+	u, err := url.Parse(r.RequestURI)
+	if err != nil {
+		return nil, err
+	}
+
 	input := map[string]interface{}{
 		"Headers":    r.RequestHeaders,
 		"Path":       r.RequestURI,
+		"PathPlain":  u.Path,
+		"PathArr":    strings.Split(u.Path, "/"),
+		"Query":      u.Query(),
 		"Method":     r.RequestMethod,
 		"Body":       body,
 		"User":       r.User,
@@ -164,7 +174,6 @@ func uuid4() (string, error) {
 	bs[6] = bs[6]&^0xf0 | 0x40
 	return fmt.Sprintf("%x-%x-%x-%x-%x", bs[0:4], bs[4:6], bs[6:8], bs[8:10], bs[10:]), nil
 }
-
 
 func regoSyntax(p string) int {
 


### PR DESCRIPTION
Currently, writing policies for pulling images from a trusted registry is cumbersome, because accessing the image name in the path `/v1.40/images/create?fromImage=registry.company.com%3A8885%2Fbash\\u0026tag=latest` is only possible with some assumptions (e.g. fromImage is always the first query param) and some string manipulation.

Hence, for reducing the complexity of writing rules, I propose with this PR to add more pre-parsed fields to the input map:
- `PathPlain` includes only the path, e.g. "/v1.40/images/create"
- `PathArr` contains the path splitted by "/"
- `Query` allows accessing query params as object

**Examples**
With the proposed changes, it is pretty straight forward to prevent Docker from pulling images from untrusted sources, e.g.:
```
package docker.authz

default allow = false

allow {
    image_from_trusted_registry
    image_from_trusted_registry2
}

image_from_trusted_registry {
    glob.match("/v*/images/create", ["/"], input.PathPlain)
    startswith(input.Query.fromImage[_], "registry.company.com:") # implies port must be set
}

image_from_trusted_registry2 {
    input.PathArr[2] == "images"
    input.PathArr[3] == "create"
    startswith(input.Query.fromImage[_], "registry.company.com:") # implies port must be set
}
```