### PR TITLE
Resolve symlinked bindmounts

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,10 @@
 package main
 
-import "testing"
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
 
 func TestNormalizeAllowPath(t *testing.T) {
 	tests := []struct {
@@ -39,6 +43,82 @@ func TestNormalizeAllowPath(t *testing.T) {
 		t.Run("Normalize allowPath", func(t *testing.T) {
 			result := normalizeAllowPath(tc.input, tc.useConf)
 			if result != tc.expected {
+				t.Errorf("Expected %v, got %v", tc.expected, result)
+			}
+		})
+	}
+}
+
+func TestListBindMounts(t *testing.T) {
+	tests := []struct {
+		statement string
+		input     string
+		expected  []BindMount
+	}{
+		{
+			statement: "parse a simple bind list",
+			input:     `{ "HostConfig": { "Binds" : [ "/var:/home", "volume:/var/lib/app:ro" ] } }`,
+			expected:  []BindMount{{"/var", false, ""}},
+		},
+		{
+			statement: "parse the readonly attribute",
+			input:     `{ "HostConfig": { "Binds" : [ "/var:/home:ro", "/home/user:/mnt:rw" ] } }`,
+			expected:  []BindMount{{"/var", true, ""}, {"/home/user", false, ""}},
+		},
+		{
+			statement: "handle when neither bind nor mounts provided",
+			input:     `{ "HostConfig": {{} }`,
+			expected:  []BindMount{},
+		},
+		{
+			statement: "handle an invalid binds list",
+			input:     `{ "HostConfig": { "Binds" : null } }`,
+			expected:  []BindMount{},
+		},
+		{
+			statement: "handle an empty binds list",
+			input:     `{ "HostConfig": { "Binds" : [] } }`,
+			expected:  []BindMount{},
+		},
+		{
+			statement: "parse a mount list",
+			input: `{ "HostConfig": { "Mounts" : [ 
+				{ "Source": "/var", "Target": "/mnt", "Type": "bind" },
+				{ "Source": "vol", "Target": "/vol", "Type": "volume", "Labels":{"color":"red"} }
+				] } }`,
+			expected: []BindMount{{"/var", false, ""}},
+		},
+		{
+			statement: "parse a readonly mount list",
+			input: `{ "HostConfig": { "Mounts" : [ 
+				{ "Source": "/var", "Target": "/mnt", "Type": "bind", "ReadOnly": true },
+				{ "Source": "/home", "Target": "/home", "Type": "bind" }
+				] } }`,
+			expected: []BindMount{{"/var", true, ""}, {"/home", false, ""}},
+		},
+		{
+			statement: "ignore an invalid mount list",
+			input: `{ "HostConfig": { "Mounts" : [ 
+				{ "Source": "/var", "Target": "/mnt", "Type": "bind", "ReadOnly": true },
+				{ "Source1": "/home", "Target": "/home", "Type": "bind" }
+				] } }`,
+			expected: []BindMount{{"/var", true, ""}},
+		},
+		{
+			statement: "ignore a mount list of the wrong type, whlile reading binds",
+			input: `{ "HostConfig": { "Binds": ["/var:/mnt/var:ro","/home:/home"],
+				"Mounts" : null } }`,
+			expected: []BindMount{{"/var", true, ""}, {"/home", false, ""}},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run("listBindMounts should "+tc.statement, func(t *testing.T) {
+			var body map[string]interface{}
+			json.Unmarshal([]byte(tc.input), &body)
+
+			result := listBindMounts(body)
+			if len(result) > 0 && len(tc.expected) > 0 && !reflect.DeepEqual(result, tc.expected) {
 				t.Errorf("Expected %v, got %v", tc.expected, result)
 			}
 		})

--- a/main_test.go
+++ b/main_test.go
@@ -67,7 +67,7 @@ func TestListBindMounts(t *testing.T) {
 		},
 		{
 			statement: "handle when neither bind nor mounts provided",
-			input:     `{ "HostConfig": {{} }`,
+			input:     `{ "HostConfig": {} }`,
 			expected:  []BindMount{},
 		},
 		{
@@ -115,7 +115,10 @@ func TestListBindMounts(t *testing.T) {
 	for _, tc := range tests {
 		t.Run("listBindMounts should "+tc.statement, func(t *testing.T) {
 			var body map[string]interface{}
-			json.Unmarshal([]byte(tc.input), &body)
+			err := json.Unmarshal([]byte(tc.input), &body)
+			if err != nil {
+				t.Fatalf("Improper JSON input - got %v for '%s'", err, tc.input)
+			}
 
 			result := listBindMounts(body)
 			if len(result) > 0 && len(tc.expected) > 0 && !reflect.DeepEqual(result, tc.expected) {


### PR DESCRIPTION
This is a more complete (includes tests and handles both Binds and Mounts objects) version of PR#61.

Compared to the original, I've

- Merged the BindsMounts, BindMountsResolved and BindMountsResolvedRO into a single object that's exposed to the policy (BindMounts).  This simplifies the Go code at the potential loss of some convenience in the Rego - however, I think it should be possible to emulate almost all use cases of the separated lists using the new object with some simple Rego
- Refactored the 'extraction (listing) of mounts' into a new function and tested it against a bunch of cases I could think of - in particular, this resolves a bug where an empty Binds list would cause a panic as well as adding (hopefully complete) parsing for Mounts
- Since we now have an object not three lists, non-resolved mounts have "Resolved": "" but with a valid Source - this works for my use case (my current policy just bans all non-resolved mounts) but may not work for everyone.  Open to other options here.

Finally, and this is a limitation of the original PR too - if you want to take advantage of the "Resolved Path" feature, this plugin practically needs to be run as root as a legacy plugin (otherwise it can't resolve all binds).  A workaround, if only a subset of the filesystem needs to be resolved, would be to pass more binds into the managed plugin.  In either case not doing this doesn't cause a bug, it just reduces the usefulness of the symlink resolution feature (which is expected).

Additionally, on some notes on the PR mechanics here, I've added a dependency on testify as it substantially simplifies the unit testing - I've included go.mod/go.sum updates but not pushed updates to the vendor folder - I figure this reduces the noise in the review, but does mean that running "go mod vendor" is required prior to build.  I've not submitted many Go PRs (and certainly none with a vendor folder, so I'm not sure what the expected convention is here).