### PR TITLE
allow to override version in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: all build
 
-VERSION := 0.8
+VERSION ?= 0.8
 GO_VERSION := 1.19.1
 GOLANGCI_LINT_VERSION := v1.49.0
 REPO := openpolicyagent/opa-docker-authz


### PR DESCRIPTION
so you e.g. embed the exact git version:

```
VERSION=$(git describe --tags | sed 's/v//') make build
```

Signed-off-by: Felix Ruess <felix.ruess@roboception.de>