### PR TITLE
Workflow for main branch that publishes plugin to ghcr.io

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,37 @@
+name: PR Check
+
+on:
+  push:
+    branches:
+    - "main"
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v3
+
+    - name: generate-tag                                                                 
+      run: |                                                                             
+        echo "TAG=$(git show -s --date=format:'%Y%m%d-%H%M' --format=%cd)" >> $GITHUB_ENV
+
+    - name: Log in to the Container registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build and publish docker plugin
+      env:
+        REPO: ghcr.io/${{ github.repository }}
+        VERSION: ${{ env.TAG }}
+      run: |
+        make plugin
+        docker plugin push "$REPO:$VERSION"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,9 +1,9 @@
-name: PR Check
+name: Release
 
 on:
   push:
-    branches:
-    - "main"
+    tags:
+    - 'v*'
 
 jobs:
   build:
@@ -15,11 +15,11 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
-    - name: generate-tag                                                                 
-      run: |                                                                             
-        echo "TAG=$(git show -s --date=format:'%Y%m%d-%H%M' --format=%cd)" >> $GITHUB_ENV
+    - name: Set TAG_NAME in Environment
+      # Subsequent jobs will be have the computed tag name
+      run: echo "TAG_NAME=${GITHUB_REF##*/}" >> $GITHUB_ENV
 
     - name: Log in to the Container registry
       uses: docker/login-action@v3
@@ -31,7 +31,7 @@ jobs:
     - name: Build and publish docker plugin
       env:
         REPO: ghcr.io/${{ github.repository }}
-        VERSION: ${{ env.TAG }}
+        VERSION: ${{ env.TAG_NAME }}
       run: |
         make plugin
-        docker plugin push "$REPO:$VERSION"
+        docker plugin push "$REPO:${TAG_NAME}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,14 +1,14 @@
 ---
-name: Post Merge
+name: Release
 
 on:
   push:
-    branches:
-      - main
+    tags:
+      - v*
 
 jobs:
   build:
-    name: Build edge
+    name: Build
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -17,6 +17,10 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
+
+      - name: Set TAG_NAME in Environment
+      # Subsequent jobs will be have the computed tag name
+        run: echo "TAG_NAME=${GITHUB_REF##*/}" >> $GITHUB_ENV
 
       - name: Log in to the Container registry
         uses: docker/login-action@v3
@@ -28,7 +32,7 @@ jobs:
       - name: Build and publish docker plugin
         env:
           REPO: ghcr.io/${{ github.repository }}
-          VERSION: edge
+          VERSION: ${{ env.TAG_NAME }}
         run: |-
           make plugin
           docker plugin push "$REPO:${TAG_NAME}"

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 VERSION ?= 0.8
 GO_VERSION := 1.19.1
 GOLANGCI_LINT_VERSION := v1.49.0
-REPO := openpolicyagent/opa-docker-authz
+REPO := openpolicyagent/opa-docker-authz-v2
 
 all: build
 

--- a/plugin.sh
+++ b/plugin.sh
@@ -10,8 +10,8 @@ docker image build -t rootfsimage .
 id=`docker container create rootfsimage true`
 docker container export "$id" | tar -x -C ./rootfs
 
-echo "Creating plugin "${REPO}-v2:${VERSION}" ..."
-docker plugin create "${REPO}-v2:${VERSION}" .
+echo "Creating plugin "${REPO}:${VERSION}" ..."
+docker plugin create "${REPO}:${VERSION}" .
 
 echo "Cleanup..."
 docker container rm -f "$id" > /dev/null


### PR DESCRIPTION
Hi and again thanks for this project!

Since it seems that the workflow for publishing new versions of the plugins is a manual process, I have added an (untested) github actions workflow that can publish the plugin to ghcr.io.
This will create a somewhat random tag, but will publish on every push to main.

If this is something that you feel is not what you want, feel free to decline this PR :) 