### PR TITLE
Makefile fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: all build
 
-VERSION ?= 0.8
+VERSION ?= 0.9
 GO_VERSION := 1.21.4
 GOLANGCI_LINT_VERSION := v1.55.2
 REPO ?= openpolicyagent/opa-docker-authz-v2
@@ -34,13 +34,13 @@ plugin: build
 
 plugin-push:
 	@for plugin in `docker plugin ls --format '{{.Name}}'`; do \
-		if [ "$$plugin" = "$(REPO)-v2:$(VERSION)" ]; then \
-		    echo "\nPushing plugin $(REPO)-v2:$(VERSION) ..."; \
-            docker plugin push $(REPO)-v2:$(VERSION); \
+		if [ "$$plugin" = "$(REPO):$(VERSION)" ]; then \
+		    echo "\nPushing plugin $(REPO):$(VERSION) ..."; \
+            docker plugin push $(REPO):$(VERSION); \
 			exit; \
 		fi \
 	done; \
-	echo "\nNo local copy of $(REPO)-v2:$(VERSION) exists, create it before attempting push"
+	echo "\nNo local copy of $(REPO):$(VERSION) exists, create it before attempting push"
 
 clean:
 	@if [ -f ./opa-docker-authz ]; then \

--- a/build.sh
+++ b/build.sh
@@ -8,7 +8,7 @@ OPA_VERSION=$(go list -m -f '{{.Version}}' github.com/open-policy-agent/opa)
 echo "Building opa-docker-authz version: $VERSION (OPA version: $OPA_VERSION)"
 
 echo -e "\nBuilding opa-docker-authz ..."
-CGO_ENABLED=0 go build -ldflags \
+CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags \
     "-X github.com/open-policy-agent/opa-docker-authz/version.Version=$VERSION -X github.com/open-policy-agent/opa-docker-authz/version.OPAVersion=$OPA_VERSION" \
     -buildvcs=false \
     -o opa-docker-authz


### PR DESCRIPTION
Bump version to v0.9 and remove the duplicate -v2 suffixes in the plugin push make task.

Also make sure to build for linux/amd64 as that's what we publish.