### PR TITLE
#86 Build plugin and images for multiple architectures

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -18,6 +18,12 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:
@@ -31,4 +37,8 @@ jobs:
           TAG_NAME: edge
         run: |-
           REPO=${{ env.REPO }} VERSION=${{ env.TAG_NAME }} make plugin
+          docker plugin push "${{ env.REPO }}:${{ env.TAG_NAME }}-linux-amd64"
+          docker plugin push "${{ env.REPO }}:${{ env.TAG_NAME }}-linux-arm64"
           docker plugin push "${{ env.REPO }}:${{ env.TAG_NAME }}"
+
+          # docker does not currently support multi-arch plugins so we cannot create a list manifest

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -10,7 +10,11 @@ jobs:
     steps:
     - name: Check out code
       uses: actions/checkout@v3
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
 
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
     - name: Build (Linux)
       run: make build
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,6 +18,12 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Set TAG_NAME in Environment
       # Subsequent jobs will be have the computed tag name
         run: echo "TAG_NAME=${GITHUB_REF##*/}" >> $GITHUB_ENV
@@ -34,4 +40,6 @@ jobs:
           REPO: ghcr.io/${{ github.repository }}
         run: |-
           REPO=${{ env.REPO }} VERSION=${{ env.TAG_NAME }} make plugin
+          docker plugin push "${{ env.REPO }}:${{ env.TAG_NAME }}-linux-amd64"
+          docker plugin push "${{ env.REPO }}:${{ env.TAG_NAME }}-linux-arm64"
           docker plugin push "${{ env.REPO }}:${{ env.TAG_NAME }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,13 @@ FROM alpine:latest as certs
 RUN apk --update add ca-certificates
 
 FROM scratch
+ARG TARGETOS
+ARG TARGETARCH
 
 LABEL maintainer="Torin Sandall <torinsandall@gmail.com>"
 
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
-COPY opa-docker-authz /opa-docker-authz
+COPY opa-docker-authz-${TARGETOS}-${TARGETARCH} /opa-docker-authz
 
 ENTRYPOINT ["/opa-docker-authz"]

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: all build
 
 VERSION ?= 0.8
-GO_VERSION := 1.21.4
+GO_VERSION := 1.22.0
 GOLANGCI_LINT_VERSION := v1.55.2
 REPO ?= openpolicyagent/opa-docker-authz-v2
 

--- a/build.sh
+++ b/build.sh
@@ -7,10 +7,23 @@ OPA_VERSION=$(go list -m -f '{{.Version}}' github.com/open-policy-agent/opa)
 
 echo "Building opa-docker-authz version: $VERSION (OPA version: $OPA_VERSION)"
 
-echo -e "\nBuilding opa-docker-authz ..."
-CGO_ENABLED=0 go build -ldflags \
-    "-X github.com/open-policy-agent/opa-docker-authz/version.Version=$VERSION -X github.com/open-policy-agent/opa-docker-authz/version.OPAVersion=$OPA_VERSION" \
-    -buildvcs=false \
-    -o opa-docker-authz
+
+platforms=("linux/amd64" "linux/arm64")
+for platform in "${platforms[@]}"
+do
+	platform_split=(${platform//\// })
+	GOOS=${platform_split[0]}
+	GOARCH=${platform_split[1]}
+
+	echo -e "\nBuilding opa-docker-authz for $platform ..."
+	CGO_ENABLED=0 GOOS=$GOOS GOARCH=$GOARCH go build -ldflags \
+	    "-X github.com/open-policy-agent/opa-docker-authz/version.Version=$VERSION -X github.com/open-policy-agent/opa-docker-authz/version.OPAVersion=$OPA_VERSION" \
+	    -buildvcs=false \
+	    -o opa-docker-authz-$GOOS-$GOARCH
+	if [ $? -ne 0 ]; then
+   		echo 'An error has occurred! Aborting the script execution...'
+		exit 1
+	fi
+done
 
 echo -e "\n... done!"

--- a/plugin.sh
+++ b/plugin.sh
@@ -6,7 +6,7 @@ set -ex
 mkdir ./rootfs
 
 echo "Creating root filesystem for plugin ..."
-docker image build -t rootfsimage .
+docker image build --load -t rootfsimage .
 id=`docker container create rootfsimage true`
 docker container export "$id" | tar -x -C ./rootfs
 
@@ -17,3 +17,29 @@ echo "Cleanup..."
 docker container rm -f "$id" > /dev/null
 docker image rm -f rootfsimage > /dev/null
 rm -rf ./rootfs
+
+
+platforms=("linux/amd64" "linux/arm64")
+for platform in "${platforms[@]}"
+do
+	platform_split=(${platform//\// })
+	GOOS=${platform_split[0]}
+	GOARCH=${platform_split[1]}
+
+	[ -d ./rootfs ] && rm -rf ./rootfs
+	mkdir ./rootfs
+
+	echo "Creating root filesystem for plugin ..."
+	docker buildx build --load --platform ${platform} -t rootfsimage-${GOOS}-${GOARCH} .
+	#docker image build -t rootfsimage .
+	id=`docker container create --platform ${platform} rootfsimage-${GOOS}-${GOARCH} true`
+	docker container export "$id" | tar -x -C ./rootfs
+
+	echo "Creating plugin "${REPO}:${VERSION}-${GOOS}-${GOARCH}" ..."
+	docker plugin create "${REPO}:${VERSION}-${GOOS}-${GOARCH}" .
+
+	echo "Cleanup..."
+	docker container rm -f "$id" > /dev/null
+	docker image rm -f rootfsimage-${GOOS}-${GOARCH} > /dev/null
+	rm -rf ./rootfs
+done


### PR DESCRIPTION
This adds support for building and publishing linux-amd64 and linux-arm64 versions of the plugin.

This fixes #86

See https://github.com/larhauga/opa-docker-authz/actions for example run and https://github.com/larhauga/opa-docker-authz/pkgs/container/opa-docker-authz for published package

I have only gotten this to work by explicitly pinning to the tag `edge-linux-arm64`/`edge-linux-amd64` and I think we can live with this solution in the interim.

---
**Details regarding multi-arch manifest list**

When trying to build a manifest list for a multi-arch tag, it does not work, and we get the following error that seems to be coming from here: https://github.com/moby/moby/blob/master/plugin/backend_linux.go#L203

```
msg="Handler for GET /v1.44/plugins/privileges returned error: did not find plugin config for specified reference ghcr.io/larhauga/opa-docker-authz:edge"
Error response from daemon: did not find plugin config for specified reference ghcr.io/larhauga/opa-docker-authz:edge
```

I have created a Q&A at the moby repo to get some input on this: https://github.com/moby/moby/discussions/47369

The manifests created with `docker manifest` does not create a manifest usable by the docker plugin system. For future references a custom manifest can be created in the following way:
```bash
curl -X PUT -H "Authorization: Bearer $(echo $GITHUB_TOKEN|base64)" -H "Content-Type: application/vnd.docker.distribution.manifest.v2+json" --data @manifest.json https://ghcr.io/v2/${{ github.repository }}/manifests/edge
```

This is the `edge-linux-amd64` manifest.
```json
{
        "schemaVersion": 2,
        "config": {
                "mediaType": "application/vnd.docker.plugin.v1+json",
                "digest": "sha256:f588fb1f8e38f38b53d49c1b79281b36c2ca64b2b16119c1c8c5b6019af7d6c6",
                "size": 836
        },
        "layers": [
                {
                        "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
                        "digest": "sha256:18eeb142bdc5e4d0b518e1b1321fa0a4863b21248ba614e07d4dcd87966e3d31",
                        "size": 13257330
                }
        ],
        "mediaType": "application/vnd.docker.distribution.manifest.v2+json"
}
```

The `:edge` manifest:
```json
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
   "manifests": [
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 419,
         "digest": "sha256:9b40bdeec15886807829ef61be7483bbc556758176944426965220cc2afe0f52",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 419,
         "digest": "sha256:aac32815a31f558589e17ed28deeb500c482d557d9038710f4e84177941d10a1",
         "platform": {
            "architecture": "arm64",
            "os": "linux"
         }
      }
   ]
}

```
