### PR TITLE
publish opa-docker-authz to seperate darwin and windows tags

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -39,6 +39,9 @@ jobs:
           REPO=${{ env.REPO }} VERSION=${{ env.TAG_NAME }} make plugin
           docker plugin push "${{ env.REPO }}:${{ env.TAG_NAME }}-linux-amd64"
           docker plugin push "${{ env.REPO }}:${{ env.TAG_NAME }}-linux-arm64"
+          docker plugin push "${{ env.REPO }}:${{ env.TAG_NAME }}-darwin-amd64"
+          docker plugin push "${{ env.REPO }}:${{ env.TAG_NAME }}-darwin-arm64"
+          docker plugin push "${{ env.REPO }}:${{ env.TAG_NAME }}-windows-amd64"
           docker plugin push "${{ env.REPO }}:${{ env.TAG_NAME }}"
 
           # docker does not currently support multi-arch plugins so we cannot create a list manifest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,4 +42,7 @@ jobs:
           REPO=${{ env.REPO }} VERSION=${{ env.TAG_NAME }} make plugin
           docker plugin push "${{ env.REPO }}:${{ env.TAG_NAME }}-linux-amd64"
           docker plugin push "${{ env.REPO }}:${{ env.TAG_NAME }}-linux-arm64"
+          docker plugin push "${{ env.REPO }}:${{ env.TAG_NAME }}-darwin-amd64"
+          docker plugin push "${{ env.REPO }}:${{ env.TAG_NAME }}-darwin-arm64"
+          docker plugin push "${{ env.REPO }}:${{ env.TAG_NAME }}-windows-amd64"
           docker plugin push "${{ env.REPO }}:${{ env.TAG_NAME }}"

--- a/build.sh
+++ b/build.sh
@@ -8,7 +8,7 @@ OPA_VERSION=$(go list -m -f '{{.Version}}' github.com/open-policy-agent/opa)
 echo "Building opa-docker-authz version: $VERSION (OPA version: $OPA_VERSION)"
 
 
-platforms=("linux/amd64" "linux/arm64")
+platforms=("linux/amd64" "linux/arm64" "darwin/amd64" "darwin/arm64" "windows/amd64")
 for platform in "${platforms[@]}"
 do
 	platform_split=(${platform//\// })

--- a/plugin.sh
+++ b/plugin.sh
@@ -19,7 +19,7 @@ docker image rm -f rootfsimage > /dev/null
 rm -rf ./rootfs
 
 
-platforms=("linux/amd64" "linux/arm64")
+platforms=("linux/amd64" "linux/arm64" "darwin/amd64" "darwin/arm64" "windows/amd64")
 for platform in "${platforms[@]}"
 do
 	platform_split=(${platform//\// })


### PR DESCRIPTION
Experimental: Build the plugin for darwin (arm + amd) architectures and for windows. Possible first step in testing https://github.com/open-policy-agent/opa-docker-authz/issues/60.
I am not sure this will work, but by publishing the images, it is easier to test.

What do you think @anderseknert ?