### PR TITLE
chore: upgrade golangci-lint to v2.1.6

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,25 +1,37 @@
-run:
-  timeout: 5m
-
-linter-settings:
-  lll:
-    line-length: 200
-
-  misspell:
-    locale: US
-
+version: "2"
 linters:
-  disable-all: true
+  default: none
   enable:
-  - errcheck
-  - govet
-  - ineffassign
-  - revive # replacement for golint
-  - gofmt
-  - goimports
-  - unused
-  - misspell
-  - typecheck
-  - staticcheck
-  - gosimple
-  # - gosec # too many false positives
+    - errcheck
+    - govet
+    - ineffassign
+    - misspell
+    - revive
+    - staticcheck
+    - unused
+  settings:
+    lll:
+      line-length: 200
+    misspell:
+      locale: US
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 VERSION ?= 0.9
 GO_VERSION := 1.24.3
-GOLANGCI_LINT_VERSION := v1.64.5
+GOLANGCI_LINT_VERSION := v2.1.6
 REPO ?= openpolicyagent/opa-docker-authz-v2
 
 REGAL_FORMAT ?= pretty

--- a/main.go
+++ b/main.go
@@ -133,7 +133,7 @@ func (p DockerAuthZPlugin) evaluatePolicyFile(ctx context.Context, r authorizati
 		log.Printf("Returning OPA policy decision: %v (error: '%v'; input: '%v')", allowed, err, string(i))
 	} else {
 		if !p.quiet {
-			if !(p.logOnlyDenied && allowed) {
+			if !p.logOnlyDenied || !allowed {
 				dl, _ := json.Marshal(decisionLog)
 				log.Printf("Returning OPA policy decision: %v: %s", allowed, string(dl))
 			}


### PR DESCRIPTION
Upgrades golangci-lint from v1.64.5 to v2.1.6.

This involves updating the version in the Makefile and migrating the .golangci.yaml configuration to the new v2 format. This includes adjustments to linter and formatter setups. A boolean expression was fixed by the linter in main.go.

Previously the linter config had a typo, which caused settings for 'lll' and 'misspell' to not get applied. This was caused by a typo in the key name "linter-settings", which should have been "linters-settings".